### PR TITLE
grape::api::boolean type 追加

### DIFF
--- a/lib/ruby-swagger/grape/type.rb
+++ b/lib/ruby-swagger/grape/type.rb
@@ -88,6 +88,9 @@ module Swagger::Grape
         'boolean' => {
           'type' => 'boolean'
         },
+        'grape::api::boolean' => {
+          'type' => 'boolean'
+        },
         'virtus::attribute::boolean' => {
           'type' => 'boolean'
         },


### PR DESCRIPTION
- Grape::API::Boolean が swagger.json 側で object になってしまうのを boolean になるように修正。